### PR TITLE
Don't overwrite data fields from inner errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -119,18 +119,9 @@ func (e *AsertoError) Err(err error) *AsertoError {
 	if err == nil {
 		return e
 	}
+
 	c := e.Copy()
-
 	c.errs = append(c.errs, err)
-
-	var aErr *AsertoError
-	if ok := errors.As(err, &aErr); ok {
-		for k, v := range aErr.data {
-			if _, ok := c.data[k]; !ok {
-				c.data[k] = v
-			}
-		}
-	}
 
 	return c
 }


### PR DESCRIPTION
When adding an inner error using `.Err(err)` we "merge" the data fields from the inner error to the outer and in the process may overwrite the fields of the outer error, including the `msg` field.
There is no reason to do that. The inner error's data fields remain in the inner error and get formatted correctly when calling `.Error()` on the outer error. 