### PR TITLE
AsertoError.Fields() includes fields from inner errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -24,7 +24,7 @@ func WrapContext(err error, ctx context.Context, message string) *ContextError {
 	return WithContext(errors.Wrap(err, message), ctx)
 }
 
-func WrapfContext(err error, ctx context.Context, format string, args ...interface{}) *ContextError {
+func WrapfContext(err error, ctx context.Context, format string, args ...any) *ContextError {
 	return WithContext(errors.Wrapf(err, format, args...), ctx)
 }
 


### PR DESCRIPTION
Prior to #17 the fields of inner errors would be copied into the `data` field of the outer message, which resulted in error message formatting that appears out of order.

However, with that behavior gone we still want the `Fields()` function to include fields from inner errors, which is what this commit achieves.